### PR TITLE
Purge css to avoid some duplicated critical css not needed

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -2,5 +2,5 @@ const http = require('http')
 const extractCssFromUrl = require('.')
 
 http.createServer(extractCssFromUrl).listen(1337, () => {
-	console.log(`Server started at http://localhost:1337`)
+  console.log(`Server started at http://localhost:1337`)
 })

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "chrome-aws-lambda": "1.12.0",
-    "css-purge": "^3.1.7",
+    "css-purge": "3.1.7",
     "puppeteer-core": "1.12.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "index.js",
   "scripts": {
     "deploy": "npx now",
-    "dev": "nodemon dev.js"
+    "dev": "ENV=dev nodemon dev.js"
   },
   "license": "MIT",
   "dependencies": {
     "chrome-aws-lambda": "1.12.0",
+    "css-purge": "^3.1.7",
     "puppeteer-core": "1.12.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Use css-purge in order to remove duplicated selectors. That could happen if the project is loading more than one CSS as the Code Coverage could return duplicated selectors and that would be positive as they're being used (while not needed). With css-purge we clean and optimize this.

In the Fotocasa example:
- Before: ~24KB
- After: ~18KB