### PR TITLE
add optional custom headers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,21 @@ This package uses an actual browser under the hood to get all the CSS and expose
 I have no idea how local testing for Now is supposed to work, so I created a tiny HTTP server in `dev.js` that calls the actual function that gets deployed.
 Run `npm run dev` to run a local version of the function for local testing.
 
+## Optional headers to the destination URL
+
+You can optionally add custom headers to the final URL that this service will navigate through. In order to achieve it, you need to do 2 things:
+
+First, add all the custom HTTP headers you want to this service request, and then define those you want to send in the URL search params `headers`.
+
+```
+GET: https://critical-css-service.now.sh/m/https://my-website.com/?headers=X-Custom-Token
+
+HEADERS:
+{
+	"X-Custom-Token": "123456"
+}
+```
+
 ## Deployment
 
 Using [Now](https://zeit.co/now): `now`.

--- a/readme.md
+++ b/readme.md
@@ -20,12 +20,10 @@ Run `npm run dev` to run a local version of the function for local testing.
 
 ## Optional headers to the destination URL
 
-You can optionally add custom headers to the final URL that this service will navigate through. In order to achieve it, you need to do 2 things:
-
-First, add all the custom HTTP headers you want to this service request, and then define those you want to send in the URL search params `headers`.
+You can optionally add custom headers to the final URL that this service will navigate through. In order to achieve it you have to add all the custom HTTP headers you want to this service request:
 
 ```
-GET: https://critical-css-service.now.sh/m/https://my-website.com/?headers=X-Custom-Token
+GET: https://critical-css-service.now.sh/m/https://my-website.com/
 
 HEADERS:
 {

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Run `npm run dev` to run a local version of the function for local testing.
 
 ## Optional headers to the destination URL
 
-You can optionally add custom headers to the final URL that this service will navigate through. In order to achieve it you have to add all the custom HTTP headers you want to this service request:
+You can optionally add all the custom HTTP headers you want to this service request, that way your destination URL request will have also such headers. See the following example:
 
 ```
 GET: https://critical-css-service.now.sh/m/https://my-website.com/


### PR DESCRIPTION
We should be able to add custom headers to the destination URL since some websites need a token in order to authenticate or even ensure the URL is executed from this service safely (in Coches.net for example we have Distil trying to ban us because it thinks this service is a bot).